### PR TITLE
Remove -webkit-font-smoothing and co. from .font

### DIFF
--- a/src/assets/css/tox-helper.css
+++ b/src/assets/css/tox-helper.css
@@ -116,12 +116,6 @@ body {
     font-smooth:always;
     text-rendering: optimizeLegibility;
 
-    -webkit-font-smoothing: antialiased;
-    -moz-font-smoothing: antialiased;
-    -o-font-smoothing: antialiased;
-    -ms-font-smoothing: antialiased;
-    font-smoothing: antialiased;
-
     cursor:default;
 }
 .font.FiraSans {


### PR DESCRIPTION
You should only be using this property when there is a real problem with the font rendering. Here it actually makes the font rendering worse.

Before
![](https://cloud.githubusercontent.com/assets/774591/6543550/b6d233e6-c4d4-11e4-9e42-a93edcedf669.png)

After
![](https://cloud.githubusercontent.com/assets/774591/6543551/c0b9b32a-c4d4-11e4-82b4-31596873469e.png)

Need some before/after shots from GNU/Linux and Windows too.