### PR TITLE
Removed unnecessary comma

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         
         <!-- SEO -->
-        <meta name="description" content="With the rise of government monitoring programs, Tox provides an easy to use application that allows you to connect with friends and family without anyone else listening in. While other big-name services require you to pay for features, Tox is totally free, and comes without advertising." />
+        <meta name="description" content="With the rise of government monitoring programs, Tox provides an easy to use application that allows you to connect with friends and family without anyone else listening in. While other big-name services require you to pay for features, Tox is totally free and comes without advertising." />
         <meta name="keywords" content="tox,messenger,instant messaging,secure,decentralized,friendly,github,open source,voice,calling" />
         
         <!-- FAVICON -->
@@ -91,7 +91,7 @@
                     <h1 class="font FiraSans light show-for-medium-only">A New Kind of Instant Messaging</h1>
                     <h1 class="font FiraSans regular show-for-small-only">A New Kind of Instant Messaging</h1>
                     
-                    <p class="font FiraSans regular small-centered small-11 medium-11 large-8 columns">With the rise of government monitoring programs, Tox provides an easy to use application that allows you to connect with friends and family without anyone else listening in. While other big-name services require you to pay for features, Tox is totally free, and comes without advertising.</p>
+                    <p class="font FiraSans regular small-centered small-11 medium-11 large-8 columns">With the rise of government monitoring programs, Tox provides an easy to use application that allows you to connect with friends and family without anyone else listening in. While other big-name services require you to pay for features, Tox is totally free and comes without advertising.</p>
                     
                     <p class="download small-centered small-10 medium-8 large-6 columns">
                         <a class="small-centered radius button small font FiraSans extrabold" data-anchor="true" onclick=mixpanel.track("new_download"); href="#download"><span id="download-platform"></span>Download qTox</a>


### PR DESCRIPTION
In the edited sentence there appeared to be an extra comma. This becomes clearer if the subordinate clause is removed:
"Tox is totally free, and comes without advertising." should be "Tox is totally free and comes without advertising."