### PR TITLE
Corrects: Font of OS for different browsers

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -142,11 +142,11 @@
               </tr>
 
               <tr data-client-name="qtox">
-                <td><a onclick=mixpanel.track("new_download_win32"); href="https://tux3-dev.tox.im/jenkins/job/qTox-win32-nsis/lastSuccessfulBuild/artifact/setup-qtox32.exe"><span class="pe-7s-cloud-download"> Win32</span></a></td>
-                <td><a onclick=mixpanel.track("new_download_win64"); href="https://tux3-dev.tox.im/jenkins/job/qTox-win64-nsis/lastSuccessfulBuild/artifact/setup-qtox64.exe"><span class="pe-7s-cloud-download"> Win64</span></a></td>		
-                <td><a onclick=mixpanel.track("new_download_osx"); href="https://jenkins.libtoxcore.so/job/qTox%20OS%20X/lastSuccessfulBuild/artifact/qtox.zip"><span class="pe-7s-cloud-download"> OS X</span></a></td>
-                <td><a onclick=mixpanel.track("new_download_android"); href="https://plus.google.com/communities/103125800027884896310"><span class="pe-7s-cloud-download"> Android</span></a></td>
-                <td><a onclick=mixpanel.track("new_download_other"); href="https://wiki.tox.im/binaries"><span class="pe-7s-cloud-download"> Others</span></a></td>
+                <td><a onclick=mixpanel.track("new_download_win32"); href="https://tux3-dev.tox.im/jenkins/job/qTox-win32-nsis/lastSuccessfulBuild/artifact/setup-qtox32.exe"><span class="pe-7s-cloud-download"> <span class="font FiraSans extrabold">Win32</span></span></a></td>
+                <td><a onclick=mixpanel.track("new_download_win64"); href="https://tux3-dev.tox.im/jenkins/job/qTox-win64-nsis/lastSuccessfulBuild/artifact/setup-qtox64.exe"><span class="pe-7s-cloud-download"> <span class="font FiraSans extrabold">Win64</span></span></a></td>		
+                <td><a onclick=mixpanel.track("new_download_osx"); href="https://jenkins.libtoxcore.so/job/qTox%20OS%20X/lastSuccessfulBuild/artifact/qtox.zip"><span class="pe-7s-cloud-download"> <span class="font FiraSans extrabold">OS X</span></span></a></td>
+                <td><a onclick=mixpanel.track("new_download_android"); href="https://plus.google.com/communities/103125800027884896310"><span class="pe-7s-cloud-download"> <span class="font FiraSans extrabold">Android</span></span></a></td>
+                <td><a onclick=mixpanel.track("new_download_other"); href="https://wiki.tox.im/binaries"><span class="pe-7s-cloud-download"> <span class="font FiraSans extrabold">Others</span></span></a></td>
               </tr>
             </table>
                 


### PR DESCRIPTION
Font for Operating System at the bottom of the site is appearing fine in
Chrome but not in FireFox. This commits adds the required classes to make
it work fine for all browsers.

Fixes #3