### PR TITLE
More friendly scrolling

### DIFF
--- a/src/assets/js/tox.bootstrap.js
+++ b/src/assets/js/tox.bootstrap.js
@@ -307,6 +307,7 @@
             Tox.s(document).on(Tox.d.events.Scroll, function(e) {
                 e.stopPropagation();
                 e.preventDefault();
+                Tox.scrollManager.Unlock(true);
                 return false;
             });
             TweenLite.to(window, 0.1, {


### PR DESCRIPTION
Earlier the user could not scroll before clicking the arrow or pressing the down key. But with this commit, he won't see the scroll bar as soon as the page will load to give a better look of the landing page and then either by pressing the down key or scrolling once, the scroll bar will appear.

Fixes #2