### PR TITLE
Add very simple alpha warning

### DIFF
--- a/src/assets/css/tox-homepage.css
+++ b/src/assets/css/tox-homepage.css
@@ -148,6 +148,9 @@ header.toxHeader section div p a.button:hover {
 header.toxHeader section div p:last-child {
     font-size:16px;
 }
+header.toxHeader section div p small#alpha-warning {
+    color:red;
+}
 header.toxHeader aside.footer {
     position:absolute;
     bottom:0;

--- a/src/index.html
+++ b/src/index.html
@@ -95,6 +95,7 @@
                     
                     <p class="download small-centered small-10 medium-8 large-6 columns">
                         <a class="small-centered radius button small font FiraSans extrabold" data-anchor="true" onclick=mixpanel.track("new_download"); href="#download"><span id="download-platform"></span>Download qTox</a>
+                        <p><small id="alpha-warning">Tox is alpha software. Please use it at your own risk.</small></p>
                     </p>
                     <p class="hide small-centered small-10 medium-8 large-6 columns font FiraSans regular">
                         <span id="download-specs"></span>


### PR DESCRIPTION
Tox hasn't been audited yet and still contains bugs. A small warning would help to protect our reputation in case of disaster. This can be removed when we reach final, but is good to keep for the time being, so people don't assume Tox will work perfectly.